### PR TITLE
feat: Add support for configurable GEMINI_MODEL via environment variable

### DIFF
--- a/api_keys.env.example
+++ b/api_keys.env.example
@@ -1,5 +1,7 @@
 TELEGRAM_API_KEY=abc
 GEMINI_API_KEY=def
+# Optional: Model to use (defaults to gemini-2.5-flash if not set)
+GEMINI_MODEL=gemini-xxxxxxxxx
 
 # Add more users separating their id with ";"
 ADMIN_USER_ID=123;456

--- a/src/configs/api_keys.py
+++ b/src/configs/api_keys.py
@@ -57,3 +57,13 @@ def get_admin_user_ids() -> list[int]:
         return [int(admin.strip()) for admin in admin_list]
     except KeyError as e:
         raise KeyError("ADMIN_USER_ID environment variable not set")
+
+def get_gemini_model() -> str:
+    """Retrieves the GEMINI_MODEL from environment variables.
+    
+    If not set, defaults to a safe standard model.
+
+    Returns:
+        str: The value of the GEMINI_MODEL environment variable or default.
+    """
+    return os.environ.get("GEMINI_MODEL", "gemini-2.5-flash")

--- a/src/gemini/api_client.py
+++ b/src/gemini/api_client.py
@@ -89,7 +89,9 @@ class GeminiAPIClient():
             response_mime_type="application/json",
         )
 
-        model_name = "gemini-1.5-flash-002"
+        # OLD: model_name = "gemini-1.5-flash-002"
+        # NEW: Fetch from environment variable
+        model_name = api_keys.get_gemini_model()
 
         self.model_info = GeminiModelInfo(
             model_name=model_name,


### PR DESCRIPTION
Currently, the Gemini model is hardcoded to gemini-1.5-flash-002. This PR introduces a new environment variable GEMINI_MODEL allowing users to switch to newer models (like gemini-2.5-flash) without modifying the source code.

Changes:

Added get_gemini_model in api_keys.py.

Updated api_client.py to use the dynamic model name.

Added example in api_keys.env.example.